### PR TITLE
list yaml recursively

### DIFF
--- a/bakerlib/software_repository.py
+++ b/bakerlib/software_repository.py
@@ -43,6 +43,6 @@ class SoftwareRepository:
     @staticmethod
     def _list_yaml_files(directory):
         files = []
-        files.extend(glob.glob("%s/*.yml" % directory))
-        files.extend(glob.glob("%s/*.yaml" % directory))
+        files.extend(glob.glob("%s/**/*.yml" % directory, recursive=True))
+        files.extend(glob.glob("%s/**/*.yaml" % directory, recursive=True))
         return files

--- a/tests/software_repository_test.py
+++ b/tests/software_repository_test.py
@@ -49,10 +49,10 @@ ANOTHER_SOFTWARE_ENRICHED = {
     "functions": ['function4', 'function5']}
 
 
-def glob_side_effect(value):
-    if value == AN_INPUT_DIR + "/*.yml":
+def glob_side_effect(value, **kwargs):
+    if value == AN_INPUT_DIR + "/**/*.yml":
         return [A_FILENAME]
-    if value == AN_INPUT_DIR + "/*.yaml":
+    if value == AN_INPUT_DIR + "/**/*.yaml":
         return [ANOTHER_FILENAME]
     return []
 
@@ -72,7 +72,7 @@ class TestSoftwareRetrieval(unittest.TestCase):
                 self.assertCountEqual(software_catalog, [A_SOFTWARE, ANOTHER_SOFTWARE])
 
     def test_should_return_no_software_if_no_files(self):
-        with patch('glob.glob', side_effect=lambda t: []) as _:
+        with patch('glob.glob', side_effect=lambda t, **kwargs: []) as _:
             software_catalog = self.under_test.get_software_catalog()
             self.assertEqual(software_catalog, [])
 


### PR DESCRIPTION
This is to avoid multiple runs of `baker.py decorate catalogue` for building images from yaml files in different sub-directories.
See https://gitlab.internal.sanger.ac.uk/sanger-pathogens/farm5-etc/-/merge_requests/570 for motivation, esp. the envisaged call of `build_images.sh`. Note that avoiding the restructuring won't help, as in the current `master` setup, no new images are built from yml files in directory `internal_softwares` (an oversight from me).